### PR TITLE
fix: linkedin link for atanu bepari

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -241,7 +241,7 @@ export const tprs_list = [
 				people: [
 					{
 						name: "Atanu BeparI",
-						linkedin_url: "www.linkedin.com/in/atanubepari",
+						linkedin_url: "https://www.linkedin.com/in/atanubepari",
 						phone_number: "8016646806",
 						email_id: "atanubepari111@gmail.com",
 					},


### PR DESCRIPTION
The LinkedIn link for Atanu Bepari is missing https protocol which results in Next.js considering it as an internal route.
This leads the user to a 404 page.

### Steps to Reproduce

Visit https://placement-portal-a5cc9.web.app/student-representative/ and click on the LinkedIn link for Atanu Bepari from CE TPR

![image](https://github.com/user-attachments/assets/14548034-98dc-405a-829c-3e75232371f4)


I added the https protocol in the link and now the link is functional.